### PR TITLE
Fix #4268, Alias "tests:drupal" Is Not Defined

### DIFF
--- a/src/Blt/Plugin/Commands/DrupalTestCommand.php
+++ b/src/Blt/Plugin/Commands/DrupalTestCommand.php
@@ -94,7 +94,7 @@ class DrupalTestCommand extends TestsCommandBase {
    * Executes tests found in either tests.phpunit or tests.drupal-tests.
    *
    * @command tests:drupal:run
-   * @aliases tdr
+   * @aliases tdr tests:drupal
    * @description Executes tests with Drupal core's testing framework. Launches chromedriver prior to execution.
    *
    * @interactGenerateSettingsFiles


### PR DESCRIPTION
## Motivation

Fixes https://github.com/acquia/blt/issues/4268

## Proposed changes
Takes the same approach as `tests:behat:run` command by adding `tests:drupal` as an command alias of `tests:drupal:run`

## Testing steps
- Run `blt tests:drupal` and verify the `tests:drupal:run` command is executed.
- Run `blt tests` and verify you don't see the error `Command "tests:drupal" is not defined`