### PR TITLE
Fixes #4351: Reset Inline Env Variables Before Running PHPUnit Tests

### DIFF
--- a/src/Blt/Plugin/Commands/PhpUnitCommand.php
+++ b/src/Blt/Plugin/Commands/PhpUnitCommand.php
@@ -55,6 +55,11 @@ class PhpUnitCommand extends DrupalTestCommand {
     $this->reportsDir = $this->getConfigValue('tests.reports.localDir') . '/phpunit';
     $this->reportFile = $this->reportsDir . '/results.xml';
     $this->phpunitConfig = $this->getConfigValue('tests.phpunit');
+
+    // Reset testing env variables.
+    $this->testingEnv = NULL;
+    $this->testingEnvString = NULL;
+
     try {
       $this->executeTests();
     }


### PR DESCRIPTION
## Motivation

Fixes https://github.com/acquia/blt/issues/4351

## Proposed changes
Since the command class properties `testingEnv` and `testingEnvString` would only be initialized when running the command `tests:drupal:phpunit:run`, I think it's safe to just reset the properties when running the `tests:phpunit:run` command and allowing the PHPUnit variables from `phpunit.xml` to be respected.

## Testing steps
- Run `blt tests` and verify both `blt tests:phpunit:run` and `tests:drupal:phpunit:run` are executed. 
- Verify there is no unexpected inline env variables when running the `blt tests:phpunit:run` command.

See unexpected variables from the screenshot
![image](https://user-images.githubusercontent.com/13445723/108889515-77e8d500-75da-11eb-9bca-6f4763bc40b1.png)